### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/Cleaner.py
+++ b/Cleaner.py
@@ -1,5 +1,12 @@
-import logging, os
+import logging
+import os
 from Constants import PASSWORD_EXTENSION_FILE
+
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 
 def runCleaner (args):
 	'''
@@ -13,9 +20,9 @@ def runCleaner (args):
 		for currentFile in files:
 			logging.debug("Processing file: {0}".format(currentFile))
 			for ext in exts:
-				if currentFile.lower().endswith(ext) : 
+				if currentFile.lower().endswith(ext) :
 					rep = raw_input("Do you want to delete this file (Y for yes): {0}/{1}? ".format(root, currentFile))
-					if rep.replace('\n','') == 'Y' : 
+					if rep.replace('\n','') == 'Y' :
 						os.remove(os.path.join(root, currentFile))
 						logging.info("Removing {0}/{1}".format(root, currentFile))
 						nbFileDeleted += 1

--- a/Mssql.py
+++ b/Mssql.py
@@ -43,8 +43,8 @@ class Mssql ():
 		self.charset = args['charset']
 		self.domain = args['domain']
 		self.args = args
-		if self.args.has_key('connection') == False : self.args['connection'] = None
-		if self.args.has_key('cursor') == False : self.args['cursor'] = None
+		if ('connection' in self.args) == False : self.args['connection'] = None
+		if ('cursor' in self.args) == False : self.args['cursor'] = None
 		self.autocommit = True
 		self.completeVersion = None
 
@@ -64,7 +64,7 @@ class Mssql ():
 		try :
 			self.args['connection'] = pymssql.connect(host=self.host, user=userString, password=self.password, database=self.database, port=self.port, charset=self.charset, login_timeout = DEFAULT_LOGIN_TIMEOUT)
 			self.args['connection'].autocommit(self.autocommit)
-		except Exception, e :
+		except Exception as e :
 			logging.debug("Connection not established : '{0}'".format(repr(e)))
 			if self.ERROR_ACCOUNT_IS_DISABLED in str(e):
 				errorMsg = "The '{0}' account is disabled".format(self.user)
@@ -91,7 +91,7 @@ class Mssql ():
 				self.args['cursor'] = self.args['connection'].cursor()
 				logging.debug("Cursor created")
 				return True
-			except Exception,e:
+			except Exception as e:
 				return ErrorClass(e)
 				
 	def update (self, host, user, password, database='master', port=1433):
@@ -114,7 +114,7 @@ class Mssql ():
 		logging.debug("Closing the connection to the {0} database server...".format(self.host))
 		if self.args['connection'] != None :
 			try: self.args['connection'].close()
-			except Exception, e: return ErrorClass(e)
+			except Exception as e: return ErrorClass(e)
 			else: 	
 				logging.debug("Connection closed")
 				return True
@@ -138,12 +138,12 @@ class Mssql ():
 		if self.args['cursor'] != None:
 			try: 
 				self.args['cursor'].execute(request)
-			except Exception, e: return ErrorClass(e)
+			except Exception as e: return ErrorClass(e)
 			else:
 				if noResult==True : return []
 				try:
 					results = self.args['cursor'].fetchall()
-				except Exception, e: return ErrorClass(e)
+				except Exception as e: return ErrorClass(e)
 				if ld==[] : return results
 				else :
 					values = []

--- a/MssqlInfo.py
+++ b/MssqlInfo.py
@@ -71,7 +71,7 @@ class MssqlInfo:
 		logging.info("The mssql-info script is sending a TCP packet to the database server to get the remote database version (without authentication)")
 		logging.debug("writing {0} bytes ".format(len(toSend)))
 		try : s.connect((self.host, self.port))
-		except Exception,e:
+		except Exception as e:
 			logging.critical("Impossible to establish a TCP connection to {0}:{1}".format(self.host,self.port))
 			return {'productName':productName, 'version:':productVersionString, 'versionNumber':productVersion}
 		s.sendall(toSend)
@@ -199,7 +199,7 @@ def runMssqlInfoModule(args):
 		mssqlInfo = MssqlInfo(args)
 		productName = mssqlInfo.__getRemoteVersionThroughTDSResponse__()
 		args['print'].title("Try to get the remote database version thanks to the TDS protocol:")
-		if productName.has_key('Version') == True and productName.has_key('ProductName') == True:
+		if ('Version' in productName) == True and ('ProductName' in productName) == True:
 			args['print'].goodNews("The SQL server version of {0}:{1}: {2} i.e. {3}".format(args['host'],args['port'], productName['Version'],productName['ProductName']))
 		else :
 			args['print'].badNews("Impossible to get the remote database version thanks to the TDS protocol")

--- a/Output.py
+++ b/Output.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 #PYTHON_TERMCOLOR_OK
+from __future__ import print_function
 try:
 	from termcolor import colored
 	TERMCOLOR_AVAILABLE = True
@@ -28,8 +29,8 @@ class Output ():
 		self.titlePos += 1
 		self.subTitlePos = 0
 		formatMesg = '\n\n[{0}] {1}: {2}'.format(self.titlePos,'({0}:{1})'.format(self.args['host'],self.args['port']),m)
-		if self.noColor == True or TERMCOLOR_AVAILABLE == False: print formatMesg
-		else : print colored(formatMesg, 'white',attrs=['bold'])
+		if self.noColor == True or TERMCOLOR_AVAILABLE == False: print(formatMesg)
+		else : print(colored(formatMesg, 'white',attrs=['bold']))
 
 	def subtitle (self, m):
 		'''
@@ -37,35 +38,35 @@ class Output ():
 		'''
 		self.subTitlePos += 1
 		formatMesg = '[{0}.{1}] {2}'.format(self.titlePos, self.subTitlePos, m)
-		if self.noColor == True  or TERMCOLOR_AVAILABLE == False: print formatMesg
-		else : print colored(formatMesg, 'white',attrs=['bold']) 
+		if self.noColor == True  or TERMCOLOR_AVAILABLE == False: print(formatMesg)
+		else : print(colored(formatMesg, 'white',attrs=['bold'])) 
 
 	def badNews (self, m):
 		'''
 		print a stop message
 		'''
 		formatMesg = '[-] {0}'.format(m)
-		if self.noColor == True  or TERMCOLOR_AVAILABLE == False: print formatMesg
-		else : print colored(formatMesg, 'red',attrs=['bold']) 
+		if self.noColor == True  or TERMCOLOR_AVAILABLE == False: print(formatMesg)
+		else : print(colored(formatMesg, 'red',attrs=['bold'])) 
 
 	def goodNews(self,m):
 		'''
 		print good news
 		'''
 		formatMesg = '[+] {0}'.format(m)
-		if self.noColor == True  or TERMCOLOR_AVAILABLE == False: print formatMesg
-		else : print colored(formatMesg, 'green',attrs=['bold']) 
+		if self.noColor == True  or TERMCOLOR_AVAILABLE == False: print(formatMesg)
+		else : print(colored(formatMesg, 'green',attrs=['bold'])) 
 
 	def unknownNews(self,m):
 		'''
 		print unknow news
 		'''
 		formatMesg = '[+] {0}'.format(m)
-		if self.noColor == True  or TERMCOLOR_AVAILABLE == False: print formatMesg
-		else : print colored(formatMesg, 'yellow',attrs=['bold']) 
+		if self.noColor == True  or TERMCOLOR_AVAILABLE == False: print(formatMesg)
+		else : print(colored(formatMesg, 'yellow',attrs=['bold'])) 
 
 	def printOSCmdOutput(self,m):
 		'''
 		print the output of a OS command
 		'''
-		print m
+		print(m)

--- a/PasswordGuesser.py
+++ b/PasswordGuesser.py
@@ -121,7 +121,7 @@ class PasswordGuesser:
 		Save this login in the trace file to known if this login has already been tested
 		If the login is in the file , return False. Otherwise return True
 		'''
-		if self.args.has_key('loginTraceFile') == False:
+		if ('loginTraceFile' in self.args) == False:
 			self.args['loginTraceFile'] = "{4}/{0}-{1}-{2}{3}".format(self.args['host'],self.args['port'],self.args['database'],PASSWORD_EXTENSION_FILE, PASSWORD_FOLDER)
 			if os.path.isfile(self.args['loginTraceFile']) == False:
 				if os.path.isdir(PASSWORD_FOLDER) == False:

--- a/Passwordstealer.py
+++ b/Passwordstealer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
 import logging
 from Mssql import Mssql
 from Utils import cleanString, ErrorClass,checkOptionsGivenByTheUser
@@ -63,7 +64,7 @@ class Passwordstealer (Mssql):
 					certificateBasedSQLServerLogins.append(anAccount['name'])
 		if self.args['save-to-file'] != None: f.close()
 		if certificateBasedSQLServerLogins != []:
-			print '\nThese following logins are certificate-based SQL server logins (for internal system use only): {0}'.format(", ".join(certificateBasedSQLServerLogins))
+			print('\nThese following logins are certificate-based SQL server logins (for internal system use only): {0}'.format(", ".join(certificateBasedSQLServerLogins)))
 		if self.args['save-to-file'] != None: logging.info("Hashed passwords saved in the file {0}".format(self.args['save-to-file']))
 		
 	def testAll (self):

--- a/ScanPorts.py
+++ b/ScanPorts.py
@@ -55,7 +55,7 @@ class ScanPorts ():
 				if self.portsQueue.empty(): thread.exit()
 				try :
 					port = self.portsQueue.get(block=False)
-				except Exception, e:
+				except Exception as e:
 					thread.exit()
 				logging.debug("Scanning {0}:{1} ... (response in max 60 secs)".format(self.ip, port))
 				response = ""

--- a/Utils.py
+++ b/Utils.py
@@ -45,7 +45,7 @@ def databaseHasBeenGiven(args):
 	Otherwise return False
 	- args must be a dictionnary
 	'''
-	if args.has_key('database') == False or args['database'] == None:
+	if ('database' in args) == False or args['database'] == None:
 		logging.critical("The database must be given thanks to the '-d DATABASE' option.")
 		return False
 	return True
@@ -56,17 +56,17 @@ def ipOrNameServerHasBeenGiven(args):
 	Otherwise return False
 	- args must be a dictionnary
 	'''
-	if args.has_key('host') == False or args['host'] == None:
+	if ('host' in args) == False or args['host'] == None:
 		logging.critical("The server addess must be given thanks to the '-s IPadress' option.")
 		return False
 	else :
 		try:
 			inet_aton(args['host'])
-		except Exception,e:
+		except Exception as e:
 			try:
 				ip = gethostbyname(args['host'])
 				args['host'] = ip
-			except Exception,e:
+			except Exception as e:
 				logging.critical("There is an error with the name server or ip address: '{0}'".format(e))
 				return False
 	return True
@@ -97,9 +97,9 @@ def anOperationHasBeenChosen(args, operations):
 	- oeprations must be a list
 	- args must be a dictionnary
 	'''
-	if args.has_key('test-module')==True and args['test-module'] == True : return True
+	if ('test-module' in args)==True and args['test-module'] == True : return True
 	for key in operations:
-		if args.has_key(key) == True:
+		if (key in args) == True:
 			if args[key] != None and args[key] != False : return True
 	logging.critical("An operation on this module must be chosen thanks to one of these options: --{0};".format(', --'.join(operations)))
 	return False

--- a/msdat.py
+++ b/msdat.py
@@ -101,13 +101,13 @@ def runAllModules(args):
 			else :
 				args['print'].goodNews("Accounts found on {0}:{1}/{2}: {3}. All modules will be started with this (these) account(s)".format(args['host'], args['port'], args['database'],validAccountsList))
 				for aLogin, aPassword in validAccountsList.items(): 
-					if connectionInformation.has_key(database) == False: connectionInformation[database] = [[aLogin,aPassword]]
+					if (database in connectionInformation) == False: connectionInformation[database] = [[aLogin,aPassword]]
 					else : connectionInformation[database].append([aLogin,aPassword])
 	else :
 		validAccountsList = {args['user']:args['password']}
 		for database in validDatabaseList:
 			for aLogin, aPassword in validAccountsList.items():
-				if connectionInformation.has_key(database) == False: connectionInformation[database] = [[aLogin,aPassword]]
+				if (database in connectionInformation) == False: connectionInformation[database] = [[aLogin,aPassword]]
 				else : connectionInformation[database].append([aLogin,aPassword])
 	#C)ALL OTHERS MODULES
 	for aDatabase in connectionInformation.keys():

--- a/progressbar.py
+++ b/progressbar.py
@@ -3,17 +3,17 @@
 #
 # progressbar  - Text progressbar library for python.
 # Copyright (c) 2005 Nilton Volpato
-# 
+#
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
 # License as published by the Free Software Foundation; either
 # version 2.1 of the License, or (at your option) any later version.
-# 
+#
 # This library is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Lesser General Public License for more details.
-# 
+#
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
@@ -54,7 +54,8 @@ __version__ = "2.2"
 # 2004-??-??: v0.1 first version
 
 
-import sys, time
+import sys
+import time
 from array import array
 try:
     from fcntl import ioctl
@@ -62,6 +63,12 @@ try:
 except ImportError:
     pass
 import signal
+
+try:
+    unicode        # Python 2
+except NameError:
+    unicode = str  # Python 3
+
 
 class ProgressBarWidget(object):
     """This is an element of ProgressBar formatting.
@@ -301,4 +308,3 @@ class ProgressBar(object):
         self.update(self.maxval)
         if self.signal_set:
             signal.signal(signal.SIGWINCH, signal.SIG_DFL)
-

--- a/texttable.py
+++ b/texttable.py
@@ -66,6 +66,8 @@ Result:
     ijkl   0.000    5.000e-78   89    0.000
     mnop   0.023    5.000e+78   92    1.280e+22
 """
+from __future__ import print_function
+from functools import reduce
 
 __all__ = ["Texttable", "ArraySizeError"]
 
@@ -179,7 +181,7 @@ class Texttable:
         """
 
         if len(array) != 4:
-            raise ArraySizeError, "array should contain 4 characters"
+            raise ArraySizeError("array should contain 4 characters")
         array = [ x[:1] for x in [ str(s) for s in array ] ]
         (self._char_horiz, self._char_vert,
             self._char_corner, self._char_header) = array
@@ -313,7 +315,7 @@ class Texttable:
         #     usable code for python 2.1
         if header:
             if hasattr(rows, '__iter__') and hasattr(rows, 'next'):
-                self.header(rows.next())
+                self.header(next(rows))
             else:
                 self.header(rows[0])
                 rows = rows[1:]
@@ -388,8 +390,8 @@ class Texttable:
         if not self._row_size:
             self._row_size = len(array)
         elif self._row_size != len(array):
-            raise ArraySizeError, "array should contain %d elements" \
-                % self._row_size
+            raise ArraySizeError("array should contain %d elements" \
+                % self._row_size)
 
     def _has_vlines(self):
         """Return a boolean, if vlines are required or not
@@ -547,7 +549,7 @@ class Texttable:
             for c in cell.split('\n'):
                 try:
                     c = unicode(c, 'utf')
-                except UnicodeDecodeError, strerror:
+                except UnicodeDecodeError as strerror:
                     sys.stderr.write("UnicodeDecodeError exception for string '%s': %s\n" % (c, strerror))
                     c = unicode(c, 'utf', 'replace')
                 array.extend(textwrap.wrap(c, width))
@@ -573,7 +575,7 @@ if __name__ == '__main__':
     table.add_rows([ ["Name", "Age", "Nickname"], 
                      ["Mr\nXavier\nHuon", 32, "Xav'"],
                      ["Mr\nBaptiste\nClement", 1, "Baby"] ])
-    print table.draw() + "\n"
+    print(table.draw() + "\n")
 
     table = Texttable()
     table.set_deco(Texttable.HEADER)
@@ -588,4 +590,4 @@ if __name__ == '__main__':
                     ["efghijk", 67.5434, .654,  89.6,  12800000000000000000000.00023],
                     ["lmn",     5e-78,   5e-78, 89.4,  .000000000000128],
                     ["opqrstu", .023,    5e+78, 92.,   12800000000000000000000]])
-    print table.draw()
+    print(table.draw())


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3.  There may be other changes required to complete a port to Python 3 but this PR is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

    See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes
