### PR TITLE
oleautomation write file still uses python2 syntax

### DIFF
--- a/OleAutomation.py
+++ b/OleAutomation.py
@@ -181,7 +181,7 @@ class OleAutomation (Mssql):
 		'''
 		logging.info("Copying the local file {0} to {1}".format(localFile, remoteFile))
 		data = getBinaryDataFromFile(localFile)
-		dataEncoded = "0x"+data.encode('hex')
+		dataEncoded = "0x"+data.hex()
 		status = self.writeFileBinary(remoteFile, dataEncoded)
 		if isinstance(status,Exception):
 			logging.info("Impossible to create the remote file {0}".format(remoteFile))

--- a/OleAutomation.py
+++ b/OleAutomation.py
@@ -181,7 +181,7 @@ class OleAutomation (Mssql):
 		'''
 		logging.info("Copying the local file {0} to {1}".format(localFile, remoteFile))
 		data = getBinaryDataFromFile(localFile)
-		dataEncoded = "0x"+data.hex()
+		dataEncoded = "0x" + data.hex()
 		status = self.writeFileBinary(remoteFile, dataEncoded)
 		if isinstance(status,Exception):
 			logging.info("Impossible to create the remote file {0}".format(remoteFile))


### PR DESCRIPTION
You will get an error as below when running the command:

~~~
./msdat.py oleautomation -s x.x.x.x -p 1433 -U sa -P sa --put-file '/home/kali/Desktop/test.txt' 'C:/temp/' 


[1] (x.x.x.x:1433): Try to copy the local file /home/kali/test.txt to C:/temp/
Traceback (most recent call last):
  File "/home/kali/pentest/tools/msdat/./msdat.py", line 394, in <module>
    main()
  File "/home/kali/pentest/tools/msdat/./msdat.py", line 389, in main
    arguments.func(args)
  File "/home/kali/pentest/tools/msdat/OleAutomation.py", line 285, in runOleAutomationModule
    data = oleAutomation.putFile(args['put-file'][0],args['put-file'][1])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/kali/pentest/tools/msdat/OleAutomation.py", line 184, in putFile
    dataEncoded = "0x"+data.encode('hex')
                       ^^^^^^^^^^^
AttributeError: 'bytes' object has no attribute 'encode'. Did you mean: 'decode'?
~~~

The change here should resolve it.